### PR TITLE
Feat/add sale

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,3 @@
+import Config
+
+config :asset_tracker, AssetTracker.Ports.Math, adapter: AssetTracker.Adapter.Math.Decimal

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,0 +1,11 @@
+{
+    "skip_files": [
+        "lib/asset_tracker/adapter/*",
+        "lib/asset_tracker/ports/*",
+        "lib/asset_tracker.ex"
+    ],
+    "coverage_options": {
+        "treat_no_relevant_line_as_covered": true,
+        "output_dir": "cover/"
+    }
+}

--- a/lib/asset_tracker.ex
+++ b/lib/asset_tracker.ex
@@ -1,18 +1,21 @@
 defmodule AssetTracker do
   @moduledoc """
-  Documentation for `AssetTracker`.
+    Delegates funcions to core
   """
 
-  @doc """
-  Hello world.
+  alias AssetTracker.Core
 
-  ## Examples
+  defdelegate new, to: Core.Tracker, as: :new
 
-      iex> AssetTracker.hello()
-      :world
+  defdelegate add_purchase(tracker, symbol, settle_date, quantity, unit_price),
+    to: Core.Tracker,
+    as: :add_purchase
 
-  """
-  def hello do
-    :world
-  end
+  defdelegate add_sale(tracker, symbol, settle_date, quantity, unit_price),
+    to: Core.Tracker,
+    as: :add_sale
+
+  defdelegate unrealized_gain_loss(tracker, symbol, market_price),
+    to: Core.Tracker,
+    as: :unrealized_gain_or_loss
 end

--- a/lib/asset_tracker/adapter/math/decimal.ex
+++ b/lib/asset_tracker/adapter/math/decimal.ex
@@ -1,0 +1,80 @@
+defmodule AssetTracker.Adapter.Math.Decimal do
+  @moduledoc """
+  Decimal adapter for Math operations
+
+  This was created because in the future we can change de Adapter for math / money operations
+  for example using Money lib
+  """
+  # Why using genserver ? To set precision, needs to be set in each process where you want it to be in affect.
+
+  @behaviour AssetTracker.Ports.Math
+
+  @type t :: Decimal.t()
+
+  @name :math_adapter
+  use GenServer
+
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, @name, name: @name)
+  end
+
+  def init(state) do
+    Decimal.Context.set(%Decimal.Context{Decimal.Context.get() | precision: 5})
+    {:ok, state}
+  end
+
+  def new(x) do
+    GenServer.call(@name, {:new, x})
+  end
+
+  def add(x, y) do
+    GenServer.call(@name, {:add, x, y})
+  end
+
+  def sub(x, y) do
+    GenServer.call(@name, {:sub, x, y})
+  end
+
+  def divide(x, y) do
+    GenServer.call(@name, {:divide, x, y})
+  end
+
+  def mult(x, y) do
+    GenServer.call(@name, {:mult, x, y})
+  end
+
+  def to_integer(x) do
+     GenServer.call(@name, {:to_integer, x})
+  end
+
+  def handle_call({:new, x}, _from, state) do
+    result = Decimal.new(x)
+    {:reply, result, state}
+  end
+
+  def handle_call({:divide, x, y}, _from, state) do
+    result = Decimal.div(x, y)
+    {:reply, result, state}
+  end
+
+  def handle_call({:mult, x, y}, _from, state) do
+    result = Decimal.mult(x, y)
+    {:reply, result, state}
+  end
+
+  def handle_call({:add, x, y}, _from, state) do
+    result = Decimal.add(x, y)
+    {:reply, result, state}
+  end
+
+  def handle_call({:sub, x, y}, _from, state) do
+    result = Decimal.sub(x, y)
+    {:reply, result, state}
+  end
+
+    def handle_call({:to_integer, x}, _from, state) do
+    result = Decimal.to_integer(x)
+    {:reply, result, state}
+  end
+end

--- a/lib/asset_tracker/adapter/math/decimal.ex
+++ b/lib/asset_tracker/adapter/math/decimal.ex
@@ -5,6 +5,7 @@ defmodule AssetTracker.Adapter.Math.Decimal do
   This was created because in the future we can change de Adapter for math / money operations
   for example using Money lib
   """
+
   # Why using genserver ? To set precision, needs to be set in each process where you want it to be in affect.
 
   @behaviour AssetTracker.Ports.Math
@@ -13,7 +14,6 @@ defmodule AssetTracker.Adapter.Math.Decimal do
 
   @name :math_adapter
   use GenServer
-
 
   def start_link(_) do
     GenServer.start_link(__MODULE__, @name, name: @name)
@@ -45,7 +45,7 @@ defmodule AssetTracker.Adapter.Math.Decimal do
   end
 
   def to_integer(x) do
-     GenServer.call(@name, {:to_integer, x})
+    GenServer.call(@name, {:to_integer, x})
   end
 
   def handle_call({:new, x}, _from, state) do
@@ -73,7 +73,7 @@ defmodule AssetTracker.Adapter.Math.Decimal do
     {:reply, result, state}
   end
 
-    def handle_call({:to_integer, x}, _from, state) do
+  def handle_call({:to_integer, x}, _from, state) do
     result = Decimal.to_integer(x)
     {:reply, result, state}
   end

--- a/lib/asset_tracker/application.ex
+++ b/lib/asset_tracker/application.ex
@@ -11,7 +11,6 @@ defmodule AssetTracker.Application do
     children = [
       # Starts a worker by calling: AssetTracker.Worker.start_link(arg)
       # {AssetTracker.Worker, arg}
-      AssetTracker,
       Math.Decimal
     ]
 

--- a/lib/asset_tracker/application.ex
+++ b/lib/asset_tracker/application.ex
@@ -4,12 +4,15 @@ defmodule AssetTracker.Application do
   @moduledoc false
 
   use Application
+  alias AssetTracker.Adapter.Math
 
   @impl true
   def start(_type, _args) do
     children = [
       # Starts a worker by calling: AssetTracker.Worker.start_link(arg)
       # {AssetTracker.Worker, arg}
+      AssetTracker,
+      Math.Decimal
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/asset_tracker/core/Errors.ex
+++ b/lib/asset_tracker/core/Errors.ex
@@ -1,0 +1,3 @@
+defmodule AssetTracker.Core.Errors do
+  def not_found, do: {:error, :nor_found}
+end

--- a/lib/asset_tracker/core/asset.ex
+++ b/lib/asset_tracker/core/asset.ex
@@ -7,7 +7,7 @@ defmodule AssetTracker.Core.Asset do
             asset_symbol: nil,
             operation_date: nil,
             quantity: nil,
-            unit_price: Decimal.new(0),
+            unit_price: 0,
             operation_type: nil
 
   @type op :: :purchase | :sale
@@ -16,7 +16,7 @@ defmodule AssetTracker.Core.Asset do
           asset_symbol :: String.t(),
           settle_date :: Date.t(),
           quantity :: integer(),
-          unit_price :: Decimal.t(),
+          unit_price :: integer(),
           operation_type :: op
         ) :: %AssetTracker.Core.Asset{}
   def new(asset_simbol, settle_date, quantity, unit_price, operation) do

--- a/lib/asset_tracker/core/tracker.ex
+++ b/lib/asset_tracker/core/tracker.ex
@@ -109,9 +109,7 @@ defmodule AssetTracker.Core.Tracker do
     paid = Decimal.mult(sale_qty, sale.unit_price)
     value = Decimal.mult(sale_qty, purchase.unit_price)
 
-    total =
-      Decimal.sub(paid, value)
-      |> Decimal.add(gain_or_loss)
+    total = calculate_gain_or_loss(paid, value, gain_or_loss)
 
     {[%Asset{purchase | quantity: pur_qty - sale_qty}] ++ purchases, total}
   end
@@ -126,11 +124,15 @@ defmodule AssetTracker.Core.Tracker do
          %Asset{quantity: sale_qty} = sale,
          gain_or_loss
        ) do
-    gain_or_loss =
-      Decimal.sub(purchase.unit_price, sale.unit_price)
-      |> Decimal.add(gain_or_loss)
+    gain_or_loss = calculate_gain_or_loss(purchase.unit_price, sale.unit_price, gain_or_loss)
 
     %{purchase | quantity: pur_qty - 1}
     |> deduct_sold_quantity(purchases, %{sale | quantity: sale_qty - 1}, gain_or_loss)
+  end
+
+  defp calculate_gain_or_loss(paid, value, initial) do
+    paid
+    |> Decimal.sub(value)
+    |> Decimal.add(initial)
   end
 end

--- a/lib/asset_tracker/core/tracker.ex
+++ b/lib/asset_tracker/core/tracker.ex
@@ -9,6 +9,8 @@ defmodule AssetTracker.Core.Tracker do
 
   alias AssetTracker.Ports.Math
 
+  alias AssetTracker.Core.Errors
+
   @doc """
   Creates a new Tracker for assets
 
@@ -37,7 +39,7 @@ defmodule AssetTracker.Core.Tracker do
     symbol = String.upcase(asset_symbol)
 
     %__MODULE__{
-      purchases: Map.update(asset_tracker.purchases, symbol, [purchase], &(&1 ++ [purchase])),
+      purchases: update_inventory(asset_tracker.purchases, symbol, purchase),
       sales: asset_tracker.sales
     }
   end
@@ -57,18 +59,25 @@ defmodule AssetTracker.Core.Tracker do
     sale = Asset.new(asset_symbol, sell_date, quantity, unit_price, :sale)
     symbol = String.upcase(asset_symbol)
 
-    case update_inventory(asset_tracker, symbol, sale) do
-      {:error, _reason} = error ->
-        error
-
-      {new_purchases, gain_or_loss} ->
-        {%__MODULE__{
-           purchases: Map.put(asset_tracker.purchases, symbol, new_purchases),
-           sales: Map.update(asset_tracker.sales, symbol, [sale], &([sale] ++ &1))
-         }, gain_or_loss}
-    end
+    asset_tracker.purchases
+    |> get_assets_by_symbol(symbol)
+    |> find_earliest_purchase()
+    |> calculate_purchases(sale)
+    |> handle_add_sale(asset_tracker, symbol, sale)
   end
 
+  def handle_add_sale({:error, _reason} = error, _asset, _symbol, _sale), do: error
+
+  def handle_add_sale({new_purchases, gain_or_loss}, asset_tracker, symbol, sale) do
+    {%__MODULE__{
+       purchases: Map.put(asset_tracker.purchases, symbol, new_purchases),
+       sales: update_inventory(asset_tracker.sales, symbol, sale)
+     }, gain_or_loss}
+  end
+
+  defp update_inventory(inventory, symbol, item) do
+    Map.update(inventory, symbol, :queue.from_list([item]), &:queue.in(item, &1))
+  end
 
   @doc """
   Calculates the unrealized gain or loss using the base formula
@@ -84,7 +93,6 @@ defmodule AssetTracker.Core.Tracker do
 
   """
 
-
   @spec unrealized_gain_or_loss(tracker :: t(), symbol :: String.t(), market_price :: integer()) ::
           map()
   def unrealized_gain_or_loss(%__MODULE__{} = tracker, symbol, market_price) do
@@ -99,17 +107,12 @@ defmodule AssetTracker.Core.Tracker do
       nil ->
         :not_found
 
-      assets when is_list(assets) ->
+      assets ->
         assets
+        |> :queue.to_list()
         |> get_median_price()
-        |> calculate_unrealized_gain_or_loss(market_price)
+        |> calculate_gain_or_loss(market_price)
     end
-  end
-
-  defp calculate_unrealized_gain_or_loss({median, total_qty}, market_price) do
-    market_price
-    |> Math.sub(median)
-    |> Math.mult(total_qty)
   end
 
   defp get_median_price(assets) do
@@ -119,40 +122,33 @@ defmodule AssetTracker.Core.Tracker do
         %{price: Math.add(price, acc.price), qty: qty + acc.qty}
       end)
 
-    {Math.divide(price, length(assets)), qty} |> IO.inspect()
+    {Math.divide(price, length(assets)), qty}
   end
 
-  defp update_inventory(tracker, symbol, sale) do
-    case get_assets_by_symbol(tracker.purchases, symbol) do
-      nil ->
-        {:error, :not_found}
+  def find_earliest_purchase(nil), do: Errors.not_found()
 
-      purchases when is_list(purchases) ->
-        purchases
-        |> find_earliest_purchase()
-        |> calculate_purchases(sale)
-    end
+  def find_earliest_purchase(purchases) do
+    {{:value, %Asset{quantity: quantity} = purchase}, queue} = :queue.out(purchases)
+    if quantity > 0, do: {purchase, :queue.to_list(queue)}, else: find_earliest_purchase(queue)
   end
 
-  defp find_earliest_purchase([%Asset{quantity: quantity} | _purchases] = total)
-       when quantity > 0,
-       do: total
-
-  defp find_earliest_purchase([_ | purchases]),
-    do: find_earliest_purchase(purchases)
+  defp calculate_purchases(purchases, asset, gain_or_loss \\ 0)
 
   defp calculate_purchases(
-         [purchase | purchases] = total,
-         %Asset{quantity: sale_qty} = sale
+         {%Asset{} = purchase, purchases},
+         %Asset{quantity: sale_qty} = sale,
+         gain_or_loss
        ) do
-    total_invetory = Enum.reduce(total, 0, &(&1.quantity + &2))
+    total_invetory = Enum.reduce(purchases, 0, &(&1.quantity + &2)) + purchase.quantity
 
     if total_invetory < sale_qty do
       {:error, :insuficient_assets}
     else
-      deduct_sold_quantity(purchase, purchases, sale, 0)
+      deduct_sold_quantity(purchase, purchases, sale, gain_or_loss)
     end
   end
+
+  defp calculate_purchases({:error, _reason}, _, _), do: Errors.not_found()
 
   defp deduct_sold_quantity(
          %Asset{quantity: pur_qty} = purchase,
@@ -161,16 +157,17 @@ defmodule AssetTracker.Core.Tracker do
          gain_or_loss
        )
        when pur_qty > sale_qty do
-    paid = Math.mult(sale_qty, sale.unit_price)
-    value = Math.mult(sale_qty, purchase.unit_price)
+    total =
+      calculate_gain_or_loss(sale.unit_price, purchase.unit_price, sale.quantity, gain_or_loss)
 
-    total = calculate_gain_or_loss(paid, value, gain_or_loss)
-
-    {[%Asset{purchase | quantity: pur_qty - sale_qty}] ++ purchases, total}
+    {:queue.from_list(purchases ++ [%Asset{purchase | quantity: pur_qty - sale_qty}]), total}
   end
 
-  defp deduct_sold_quantity(%Asset{quantity: 0}, [purchase | purchases], sale, gain_or_loss) do
-    deduct_sold_quantity(purchase, purchases, sale, gain_or_loss)
+  defp deduct_sold_quantity(%Asset{quantity: 0}, purchases, sale, gain_or_loss) do
+    purchases
+    |> :queue.from_list()
+    |> find_earliest_purchase()
+    |> calculate_purchases(sale, gain_or_loss)
   end
 
   defp deduct_sold_quantity(
@@ -185,11 +182,18 @@ defmodule AssetTracker.Core.Tracker do
     |> deduct_sold_quantity(purchases, %{sale | quantity: sale_qty - 1}, gain_or_loss)
   end
 
-  defp calculate_gain_or_loss(paid, value, initial) do
+  defp calculate_gain_or_loss(paid, value, qty \\ 1, initial) do
     paid
     |> Math.sub(value)
+    |> Math.mult(qty)
     |> Math.add(initial)
   end
 
-  defp get_assets_by_symbol(tracker, symbol), do: Map.get(tracker, symbol)
+  defp calculate_gain_or_loss({median, total_qty}, market_price) do
+    market_price
+    |> Math.sub(median)
+    |> Math.mult(total_qty)
+  end
+
+  def get_assets_by_symbol(tracker, symbol), do: Map.get(tracker, symbol)
 end

--- a/lib/asset_tracker/core/tracker.ex
+++ b/lib/asset_tracker/core/tracker.ex
@@ -25,13 +25,13 @@ defmodule AssetTracker.Core.Tracker do
   @spec add_purchase(
           asset_tracker :: t(),
           asset_symbol :: String.t(),
-          sell_date :: Date.t(),
+          settle :: Date.t(),
           quantity :: integer(),
           unit_price :: integer()
         ) :: t()
-  def add_purchase(asset_tracker, asset_symbol, sell_date, quantity, unit_price)
+  def add_purchase(asset_tracker, asset_symbol, settle_date, quantity, unit_price)
       when quantity > 0 and unit_price > 0 do
-    purchase = Asset.new(asset_symbol, sell_date, quantity, Decimal.new(unit_price), :purchase)
+    purchase = Asset.new(asset_symbol, settle_date, quantity, Decimal.new(unit_price), :purchase)
     symbol = String.upcase(asset_symbol)
 
     %__MODULE__{
@@ -42,4 +42,95 @@ defmodule AssetTracker.Core.Tracker do
 
   def add_purchase(_asset_tracker, _asset_symbol, _sell_date, _quantity, _unit_price),
     do: {:error, "The quantity and value must be grather than zero"}
+
+  @spec add_sale(
+          asset_tracker :: t(),
+          asset_symbol :: String.t(),
+          seltle_date :: Date.t(),
+          quantity :: integer(),
+          unit_price :: integer()
+        ) :: {t(), Decimal.t()}
+  def add_sale(asset_tracker, asset_symbol, sell_date, quantity, unit_price)
+      when quantity > 0 and unit_price > 0 do
+    sale = Asset.new(asset_symbol, sell_date, quantity, Decimal.new(unit_price), :sale)
+    symbol = String.upcase(asset_symbol)
+
+    case update_inventory(asset_tracker, symbol, sale) do
+      {:error, _reason} = error ->
+        error
+
+      {new_purchases, gain_or_loss} ->
+        {%__MODULE__{
+           purchases: Map.put(asset_tracker.purchases, symbol, new_purchases),
+           sales: Map.update(asset_tracker.sales, symbol, [sale], &(&1 ++ [sale]))
+         }, gain_or_loss}
+    end
+  end
+
+  defp update_inventory(tracker, symbol, sale) do
+    case Map.get(tracker.purchases, symbol) do
+      nil ->
+        {:error, :not_found}
+
+      purchases when is_list(purchases) ->
+        purchases
+        |> find_earliest_purchase()
+        |> calculate_purchases(sale)
+    end
+  end
+
+  defp find_earliest_purchase([%Asset{quantity: quantity} | _purchases] = total)
+       when quantity > 0,
+       do: total
+
+  defp find_earliest_purchase([_ | purchases]),
+    do: find_earliest_purchase(purchases)
+
+  defp calculate_purchases(
+         [purchase | purchases] = total,
+         %Asset{quantity: sale_qty} = sale
+       ) do
+    total_invetory = Enum.reduce(total, 0, &(&1.quantity + &2))
+
+    if total_invetory < sale_qty do
+      {:error, :insuficient_assets}
+    else
+      deduct_sold_quantity(purchase, purchases, sale, Decimal.new(0))
+    end
+  end
+
+  defp deduct_sold_quantity(
+         %Asset{quantity: pur_qty} = purchase,
+         purchases,
+         %Asset{quantity: sale_qty} = sale,
+         gain_or_loss
+       )
+       when pur_qty > sale_qty do
+    paid = Decimal.mult(sale_qty, sale.unit_price)
+    value = Decimal.mult(sale_qty, purchase.unit_price)
+
+    total =
+      Decimal.sub(paid, value)
+      |> Decimal.add(gain_or_loss)
+
+    {[%Asset{purchase | quantity: pur_qty - sale_qty}] ++ purchases, total}
+  end
+
+  defp deduct_sold_quantity(%Asset{quantity: 0}, [purchase | purchases], sale, gain_or_loss) do
+    deduct_sold_quantity(purchase, purchases, sale, gain_or_loss)
+  end
+
+  defp deduct_sold_quantity(
+         %Asset{quantity: pur_qty} = purchase,
+         purchases,
+         %Asset{quantity: sale_qty} = sale,
+         gain_or_loss
+       ) do
+    gain_or_loss =
+      Decimal.sub(purchase.unit_price, sale.unit_price)
+      |> Decimal.add(gain_or_loss)
+
+    %{purchase | quantity: pur_qty - 1}
+    |> deduct_sold_quantity(purchases, %{sale | quantity: sale_qty - 1}, gain_or_loss)
+  end
 end

--- a/lib/asset_tracker/ports/math.ex
+++ b/lib/asset_tracker/ports/math.ex
@@ -44,7 +44,7 @@ defmodule AssetTracker.Ports.Math do
   @spec divide(x :: param(), y :: param()) :: t()
   defdelegate divide(x, y), to: @adapter
 
-   @doc """
+  @doc """
    Receives an input type t(), and turns into integer
   """
   @spec to_integer(x :: t()) :: integer()

--- a/lib/asset_tracker/ports/math.ex
+++ b/lib/asset_tracker/ports/math.ex
@@ -47,6 +47,6 @@ defmodule AssetTracker.Ports.Math do
    @doc """
    Receives an input type t(), and turns into integer
   """
-  @spec to_integer(x :: t()) :: t()
+  @spec to_integer(x :: t()) :: integer()()
   defdelegate to_integer(x), to: @adapter
 end

--- a/lib/asset_tracker/ports/math.ex
+++ b/lib/asset_tracker/ports/math.ex
@@ -47,6 +47,6 @@ defmodule AssetTracker.Ports.Math do
    @doc """
    Receives an input type t(), and turns into integer
   """
-  @spec to_integer(x :: t()) :: integer()()
+  @spec to_integer(x :: t()) :: integer()
   defdelegate to_integer(x), to: @adapter
 end

--- a/lib/asset_tracker/ports/math.ex
+++ b/lib/asset_tracker/ports/math.ex
@@ -1,0 +1,52 @@
+defmodule AssetTracker.Ports.Math do
+  @moduledoc """
+  Interface for interacting with Math Providers
+  """
+  @adapter Application.compile_env!(:asset_tracker, [__MODULE__, :adapter])
+
+  @type t :: @adapter.t()
+  @type param :: integer() | @adapter.t()
+
+  @callback add(x :: param(), y :: param()) :: t()
+  @callback sub(x :: param(), y :: param()) :: t()
+  @callback new(x :: param()) :: t()
+  @callback mult(x :: param(), y :: param()) :: t()
+  @callback divide(x :: param(), y :: param()) :: t()
+  @callback to_integer(x :: t()) :: integer()
+
+  @doc """
+    Add two numbers x + y
+  """
+  @spec add(x :: param(), y :: param()) :: t()
+  defdelegate add(x, y), to: @adapter
+
+  @doc """
+    Sub two numbers x - y
+  """
+  @spec sub(x :: param(), y :: param()) :: t()
+  defdelegate sub(x, y), to: @adapter
+
+  @doc """
+    Creates a new instance of adapter type
+  """
+  @spec new(x :: param()) :: t()
+  defdelegate new(x), to: @adapter
+
+  @doc """
+    Multiply two numbers x * y
+  """
+  @spec mult(x :: param(), y :: param()) :: t()
+  defdelegate mult(x, y), to: @adapter
+
+  @doc """
+    Divide  two numbers x / y
+  """
+  @spec divide(x :: param(), y :: param()) :: t()
+  defdelegate divide(x, y), to: @adapter
+
+   @doc """
+   Receives an input type t(), and turns into integer
+  """
+  @spec to_integer(x :: t()) :: t()
+  defdelegate to_integer(x), to: @adapter
+end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,14 @@ defmodule AssetTracker.MixProject do
       version: "0.1.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      test_coverage: [tool: ExCoveralls],
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
+      ]
     ]
   end
 
@@ -25,7 +32,8 @@ defmodule AssetTracker.MixProject do
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
       {:uuid, "~> 1.1"},
-      {:decimal, "~> 2.0"}
+      {:decimal, "~> 2.0"},
+      {:excoveralls, "~> 0.10", only: :test}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
 %{
   "decimal": {:hex, :decimal, "2.1.1", "5611dca5d4b2c3dd497dec8f68751f1f1a54755e8ed2a966c2633cf885973ad6", [:mix], [], "hexpm", "53cfe5f497ed0e7771ae1a475575603d77425099ba5faef9394932b35020ffcc"},
+  "excoveralls": {:hex, :excoveralls, "0.17.1", "83fa7906ef23aa7fc8ad7ee469c357a63b1b3d55dd701ff5b9ce1f72442b2874", [:mix], [{:castore, "~> 1.0", [hex: :castore, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "95bc6fda953e84c60f14da4a198880336205464e75383ec0f570180567985ae0"},
+  "jason": {:hex, :jason, "1.4.1", "af1504e35f629ddcdd6addb3513c3853991f694921b1b9368b0bd32beb9f1b63", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "fbb01ecdfd565b56261302f7e1fcc27c4fb8f32d56eab74db621fc154604a7a1"},
   "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm", "c790593b4c3b601f5dc2378baae7efaf5b3d73c4c6456ba85759905be792f2ac"},
 }

--- a/test/asset_tracker/core/tracker_test.exs
+++ b/test/asset_tracker/core/tracker_test.exs
@@ -4,6 +4,8 @@ defmodule AssetTracker.Core.TrackerTest do
   alias AssetTracker.Core.Tracker
   alias AssetTracker.Core.Asset
 
+  alias AssetTracker.Ports.Math
+
   describe "Core Asset Tracker" do
     setup do
       tracker = Tracker.new()
@@ -33,7 +35,7 @@ defmodule AssetTracker.Core.TrackerTest do
                sales: %{}
              } = Tracker.add_purchase(tracker, "GOOGL", date, 10, 19)
 
-      assert ^price = Decimal.new("19")
+      assert ^price = 19
     end
 
     test "error on add purchases with invalid quantity", %{tracker: tracker} do
@@ -61,15 +63,15 @@ defmodule AssetTracker.Core.TrackerTest do
                     %AssetTracker.Core.Asset{
                       id: _,
                       asset_symbol: "GOOGL",
-                      operation_date: ~D[2023-09-29],
+                      operation_date: _,
                       quantity: first_purchase_quantity_res,
                       unit_price: res_price_first,
                       operation_type: :purchase
                     },
                     %AssetTracker.Core.Asset{
-                      id: "63b75fe9-e8bc-4183-8164-1a499f67bc83",
+                      id: _,
                       asset_symbol: "GOOGL",
-                      operation_date: ~D[2023-09-29],
+                      operation_date: _,
                       quantity: 10,
                       unit_price: res_price_second,
                       operation_type: :purchase
@@ -81,7 +83,7 @@ defmodule AssetTracker.Core.TrackerTest do
                     %AssetTracker.Core.Asset{
                       id: _,
                       asset_symbol: "GOOGL",
-                      operation_date: ~D[2023-09-29],
+                      operation_date: _,
                       quantity: 5,
                       unit_price: res_sold,
                       operation_type: :sale
@@ -95,13 +97,13 @@ defmodule AssetTracker.Core.TrackerTest do
                |> Tracker.add_purchase("GOOGL", Date.utc_today(), 10, price_second)
                |> Tracker.add_sale(symbol, Date.utc_today(), 5, sold)
 
-      purchase = Decimal.mult(price_first, 5)
-      paid = Decimal.mult(sold, 5)
-      assert gain_or_loss == Decimal.sub(paid, purchase)
+      purchase = Math.mult(price_first, 5)
+      paid = Math.mult(sold, 5)
+      assert gain_or_loss == Math.sub(paid, purchase)
 
-      assert res_price_first == Decimal.new(price_first)
-      assert res_price_second == Decimal.new(price_second)
-      assert res_sold == Decimal.new(sold)
+      assert res_price_first == price_first
+      assert res_price_second == price_second
+      assert res_sold == sold
       assert first_purchase_quantity_res == 10 - 5
     end
 
@@ -140,6 +142,21 @@ defmodule AssetTracker.Core.TrackerTest do
                tracker
                |> Tracker.add_purchase("GOOGL", Date.utc_today(), 5, 1000)
                |> Tracker.add_sale("APPL", Date.utc_today(), 15, 2000)
+    end
+
+    test "calculate unrealized gain or loss for sales and purchases", %{tracker: tracker} do
+      symbol = "APPL"
+
+      tracker =
+        tracker
+        |> Tracker.add_purchase(symbol, Date.utc_today(), 10, 10)
+        |> Tracker.add_purchase(symbol, Date.utc_today(), 12, 11)
+
+
+       {tracker, _}  = tracker
+        |> Tracker.add_sale(symbol, Date.utc_today(), 6, 10)
+
+      assert "" = Tracker.unrealized_gain_or_loss(tracker, symbol, 15)
     end
   end
 end

--- a/test/asset_tracker/core/tracker_test.exs
+++ b/test/asset_tracker/core/tracker_test.exs
@@ -14,7 +14,7 @@ defmodule AssetTracker.Core.TrackerTest do
       assert %Tracker{purchases: %{}, sales: %{}} = Tracker.new()
     end
 
-    test "add_sale/5", %{tracker: tracker} do
+    test "add_purchase/5", %{tracker: tracker} do
       date = Date.utc_today()
 
       assert %Tracker{
@@ -47,6 +47,99 @@ defmodule AssetTracker.Core.TrackerTest do
 
       assert {:error, "The quantity and value must be grather than zero"} =
                Tracker.add_purchase(tracker, "GOOGL", date, -1, 19)
+    end
+
+    test "add_sale/5", %{tracker: tracker} do
+      symbol = "GOOGL"
+      price_first = 5
+      price_second = 10
+      sold = 12
+
+      assert {%AssetTracker.Core.Tracker{
+                purchases: %{
+                  "GOOGL" => [
+                    %AssetTracker.Core.Asset{
+                      id: _,
+                      asset_symbol: "GOOGL",
+                      operation_date: ~D[2023-09-29],
+                      quantity: first_purchase_quantity_res,
+                      unit_price: res_price_first,
+                      operation_type: :purchase
+                    },
+                    %AssetTracker.Core.Asset{
+                      id: "63b75fe9-e8bc-4183-8164-1a499f67bc83",
+                      asset_symbol: "GOOGL",
+                      operation_date: ~D[2023-09-29],
+                      quantity: 10,
+                      unit_price: res_price_second,
+                      operation_type: :purchase
+                    }
+                  ]
+                },
+                sales: %{
+                  "GOOGL" => [
+                    %AssetTracker.Core.Asset{
+                      id: _,
+                      asset_symbol: "GOOGL",
+                      operation_date: ~D[2023-09-29],
+                      quantity: 5,
+                      unit_price: res_sold,
+                      operation_type: :sale
+                    }
+                  ]
+                }
+              },
+              gain_or_loss} =
+               tracker
+               |> Tracker.add_purchase("GOOGL", Date.utc_today(), 10, price_first)
+               |> Tracker.add_purchase("GOOGL", Date.utc_today(), 10, price_second)
+               |> Tracker.add_sale(symbol, Date.utc_today(), 5, sold)
+
+      purchase = Decimal.mult(price_first, 5)
+      paid = Decimal.mult(sold, 5)
+      assert gain_or_loss == Decimal.sub(paid, purchase)
+
+      assert res_price_first == Decimal.new(price_first)
+      assert res_price_second == Decimal.new(price_second)
+      assert res_sold == Decimal.new(sold)
+      assert first_purchase_quantity_res == 10 - 5
+    end
+
+    test "Always update inventory based on FIFO", %{tracker: tracker} do
+      first = 10
+      second = 20
+      symbol = "GOOGL"
+
+      tracker =
+        tracker
+        |> Tracker.add_purchase(symbol, Date.utc_today(), first, 10)
+        |> Tracker.add_purchase(symbol, Date.utc_today(), second, 11)
+
+      assets = Map.get(tracker.purchases, symbol)
+
+      assert [%{quantity: ^first}, %{quantity: ^second, id: second_id}] = assets
+
+      {tracker, _} =
+        tracker
+        |> Tracker.add_sale(symbol, Date.utc_today(), 10, 5)
+
+      assets = Map.get(tracker.purchases, symbol)
+
+      assert [%{quantity: ^second, id: ^second_id}] = assets
+    end
+
+    test "returns error on sale if total invetory is less than sale qty", %{tracker: tracker} do
+      assert {:error, :insuficient_assets} =
+               tracker
+               |> Tracker.add_purchase("GOOGL", Date.utc_today(), 5, 1000)
+               |> Tracker.add_sale("GOOGL", Date.utc_today(), 15, 2000)
+    end
+
+    test "returns error on sale if does not have the asset on inventory", %{tracker: tracker} do
+      assert {:error, :not_found} =
+               tracker
+               |> Tracker.add_purchase("GOOGL", Date.utc_today(), 5, 1000)
+               |> Tracker.add_sale("APPL", Date.utc_today(), 15, 2000)
     end
   end
 end

--- a/test/asset_tracker/core/tracker_test.exs
+++ b/test/asset_tracker/core/tracker_test.exs
@@ -161,5 +161,11 @@ defmodule AssetTracker.Core.TrackerTest do
       assert p == Math.new(p)
       assert s == Math.new(s)
     end
+
+    test "returns error if no has no asset in inventory on unrealized_gain_or_loss call", %{tracker: tracker} do
+
+      assert %{purchases: :not_found, sales: :not_found} = Tracker.unrealized_gain_or_loss(tracker, "ADDR", 15)
+
+    end
   end
 end

--- a/test/asset_tracker/core/tracker_test.exs
+++ b/test/asset_tracker/core/tracker_test.exs
@@ -162,10 +162,11 @@ defmodule AssetTracker.Core.TrackerTest do
       assert s == Math.new(s)
     end
 
-    test "returns error if no has no asset in inventory on unrealized_gain_or_loss call", %{tracker: tracker} do
-
-      assert %{purchases: :not_found, sales: :not_found} = Tracker.unrealized_gain_or_loss(tracker, "ADDR", 15)
-
+    test "returns error if no has no asset in inventory on unrealized_gain_or_loss call", %{
+      tracker: tracker
+    } do
+      assert %{purchases: :not_found, sales: :not_found} =
+               Tracker.unrealized_gain_or_loss(tracker, "ADDR", 15)
     end
   end
 end


### PR DESCRIPTION
Add sales and calc unrealized_gain_or_loss
## Details
- Create func to add_sale to tracker
- Create func to  cal unrealized_gain_or_loss
- Refactor queue
- 100% coverage tests
- Create Port and Adapter to Math modules

- Describe details here
Coverage 

![image](https://github.com/eltoncampos1/asset-tracker/assets/56568406/0afdd200-9939-44ba-8bf3-8663c667282e)

